### PR TITLE
Execute a passed block after any failed test.

### DIFF
--- a/spec/retry_spec.rb
+++ b/spec/retry_spec.rb
@@ -35,4 +35,21 @@ describe 'retry' do
       raise FooError if rand(10) != 0
     end
   end
+
+  describe 'block' do
+    let(:value) { 99 }
+    let(:failed_attempts) { 0 }
+
+    around do |example|
+      repeat example, 100.times, clear_let: false do |i, _ex, _example, ctx|
+        ctx.send(:__memoized).instance_variable_get(:@memoized)[:value] = value - 1
+        ctx.send(:__memoized).instance_variable_get(:@memoized)[:failed_attempts] = i + 1
+      end
+    end
+
+    it 'works' do
+      expect(value).to eq(0)
+      expect(failed_attempts).to eq(99)
+    end
+  end
 end


### PR DESCRIPTION
Hi @rstacruz, thanks for the really useful gem! 

I've added an option to pass a block to the repeat definition which allows arbitrary code to be executed if a spec fails. 

I hope you think it's a useful addition to the gem. 

